### PR TITLE
Bump version to 0.3

### DIFF
--- a/python2template.py
+++ b/python2template.py
@@ -20,7 +20,6 @@ This template passes flake8
 
 2018/04/11  rharolde@umich.edu
 todo:
--vvv verbose flags using logging
 """
 
 # double underscore names
@@ -34,7 +33,7 @@ import configargparse
 # defaults
 CONFIG_FILE = '.python2template.ini'
 
-# DEFINE GLOBAL VARIABLES
+# define global variables
 
 
 def debug(debug_type, msg):

--- a/python2template.py
+++ b/python2template.py
@@ -46,7 +46,7 @@ def debug(debug_type, msg):
 def python2template():
     """docstring for python2template function QQQQ"""
     # MAIN
-    debug('verbose', 'verbose mode')
+    debug('config', 'config mode')
     logging.info('logging is at info or above')
     logging.debug('logging is at debug or above')
     print 'do something QQQQ'
@@ -67,14 +67,14 @@ if __name__ == "__main__":
     config.add('--version', action='version', version=__progname__ + ".py "
                + __version__)
     config.add_argument('-v', '--verbose', action='count',
-                        help='can be repeated up to three times')
+                        help='can be repeated up to two times')
     options = config.parse_args()
     if not options.debugflags:
         options.debugflags = []     # default to empty list rather than None
     logger = logging.getLogger()
     if options.verbose:
-        if options.verbose > 3:
-            logging.warning('verbose was repeated more than three times')
+        if options.verbose > 2:
+            logging.warning('verbose was repeated more than two times')
             config.print_help()
         if options.verbose == 1:
             logger.setLevel(logging.INFO)

--- a/python2template.py
+++ b/python2template.py
@@ -24,7 +24,7 @@ todo:
 
 # double underscore names
 __progname__ = 'python2template'
-__version__ = '0.2'
+__version__ = '0.3'
 
 # from pprint import pprint
 import logging

--- a/test_python2template.py
+++ b/test_python2template.py
@@ -107,6 +107,7 @@ def test_debug():
     output = subprocess.check_output(["./" + PACKAGENAME + ".py", "-d",
                                       "config"])
     assert 'Command Line Args:   -d config' in output
+    assert 'config mode' in output
 
 
 def test_debug_long():
@@ -142,14 +143,23 @@ def test_config_file_variable():
     assert MYPACKAGE.CONFIG_FILE  # defined and not zero length
 
 
-def test_config_file():
-    '''check that config_file is read'''
+def test_default_config_file():
+    '''check that default config_file is read'''
     with open(MYPACKAGE.CONFIG_FILE, 'w') as filehandle:
         filehandle.write('debug=config\n')
     output = subprocess.check_output(["./" + PACKAGENAME + ".py"])
     os.remove(MYPACKAGE.CONFIG_FILE)
     assert 'Config File (.python2template.ini):\n  debug:             config' \
         in output
+
+
+def test_command_line_config_file():
+    '''check that command line config_file is read'''
+    output = subprocess.check_output(["./" + PACKAGENAME + ".py",
+                                      "--configfile",
+                                      ".python2template.ini.sample"])
+    assert 'Config File (.python2template.ini.sample):' in output
+    assert 'debug:             config' in output
 
 
 def test_no_qqqq():


### PR DESCRIPTION
verbose and debug options working
passes flake8
passes pylint with fix for variable names in .pylintrc
